### PR TITLE
Point pypi's project page to Azure/pytest-azurepipelines which seems …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     maintainer='Anthony Shaw',
     maintainer_email='anthonyshaw@apache.org',
     license='MIT',
-    url='https://github.com/tonybaloney/pytest-azurepipelines',
+    url='https://github.com/Azure/pytest-azurepipelines',
     description='Formatting PyTest output for Azure Pipelines UI',
     long_description=read('README.rst'),
     py_modules=['pytest_azurepipelines'],


### PR DESCRIPTION
…to be the upstream at the moment

    It also has opened issues and pull requests,

    PyPI also seems to be drawing stats like prs/stars/etc from the set gitgub uri